### PR TITLE
feat(stt): make Nemotron default STT with Whisper fallback

### DIFF
--- a/.env
+++ b/.env
@@ -2,11 +2,23 @@ LIVEKIT_URL=http://livekit:7880
 LIVEKIT_API_KEY=devkey
 LIVEKIT_API_SECRET=secret
 NEXT_PUBLIC_LIVEKIT_URL=http://localhost:7880
+
 LLAMA_BASE_URL=http://llama_cpp:11434/v1
 LLAMA_MODEL=qwen3-4b
 LLAMA_MODEL_ALIAS=qwen3-4b
 LLAMA_HF_REPO=unsloth/Qwen3-4B-Instruct-2507-GGUF
 LLAMA_HOST_PORT=11436
 LLAMA_CTX_SIZE=16384
-KOKORO_IMAGE=ghcr.io/remsky/kokoro-fastapi-cpu:latest
+
+# STT defaults to Nemotron (faster than Whisper in most local setups)
+STT_PROVIDER=nemotron
+STT_BASE_URL=http://nemotron:8000/v1
+STT_MODEL=nemotron-speech-streaming
+STT_API_KEY=no-key-needed
+NEMOTRON_MODEL_NAME=nvidia/nemotron-speech-streaming-en-0.6b
+NEMOTRON_MODEL_ID=nemotron-speech-streaming
+
+# Optional Whisper fallback (run with: docker compose --profile whisper ...)
 VOXBOX_HF_REPO_ID=Systran/faster-whisper-small
+
+KOKORO_IMAGE=ghcr.io/remsky/kokoro-fastapi-cpu:latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 venv/
 inference/llama/models/
+
+# Python cache artifacts
+**/__pycache__/
+*.pyc

--- a/docker-compose.gpu.yml
+++ b/docker-compose.gpu.yml
@@ -9,6 +9,14 @@ services:
     gpus: all
     environment:
       - LLAMA_ARG_N_GPU_LAYERS=${LLAMA_N_GPU_LAYERS:-35}
+
+  nemotron:
+    build:
+      args:
+        NEMOTRON_BASE: ${NEMOTRON_BASE:-nvidia/cuda:12.4.1-cudnn-runtime-ubuntu22.04}
+        TORCH_INDEX_URL: ${NEMOTRON_TORCH_INDEX_URL:-https://download.pytorch.org/whl/cu124}
+    gpus: all
+
   whisper:
     build:
       args:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,31 @@ services:
     networks:
       - agent_network
 
+  nemotron:
+    build:
+      context: ./inference/nemotron
+      args:
+        NEMOTRON_BASE: ${NEMOTRON_BASE:-python:3.10-slim}
+        TORCH_INDEX_URL: ${NEMOTRON_TORCH_INDEX_URL:-https://download.pytorch.org/whl/cpu}
+    volumes:
+      - nemotron-cache:/root/.cache/huggingface
+    environment:
+      - NEMOTRON_MODEL_NAME=${NEMOTRON_MODEL_NAME:-nvidia/nemotron-speech-streaming-en-0.6b}
+      - NEMOTRON_MODEL_ID=${NEMOTRON_MODEL_ID:-nemotron-speech-streaming}
+      - PYTORCH_ENABLE_MPS_FALLBACK=1
+    ports:
+      - "11435:8000"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://localhost:8000/health | grep -q '\"model_loaded\":true'"]
+      interval: 10s
+      timeout: 5s
+      retries: 120
+      start_period: 20s
+    networks:
+      - agent_network
+
   whisper:
+    profiles: ["whisper"]
     build:
       context: ./inference/whisper
     volumes:
@@ -26,7 +50,7 @@ services:
       - VOXBOX_DEVICE=${VOXBOX_DEVICE:-cpu}
       - DATA_DIR=/data
     ports:
-      - "11435:80"
+      - "11437:80"
     networks:
       - agent_network
 
@@ -76,8 +100,8 @@ services:
         condition: service_started
       kokoro:
         condition: service_started
-      whisper:
-        condition: service_started
+      nemotron:
+        condition: service_healthy
       llama_cpp:
         condition: service_healthy
     healthcheck:
@@ -106,6 +130,7 @@ services:
       - agent_network
 
 volumes:
+  nemotron-cache:
   whisper-data:
 
 networks:

--- a/inference/nemotron/Dockerfile
+++ b/inference/nemotron/Dockerfile
@@ -1,0 +1,40 @@
+# syntax=docker/dockerfile:1.5
+ARG NEMOTRON_BASE=python:3.10-slim
+FROM ${NEMOTRON_BASE}
+
+ENV PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PYTHONUNBUFFERED=1 \
+    PYTORCH_ENABLE_MPS_FALLBACK=1
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+      build-essential \
+      ca-certificates \
+      curl \
+      ffmpeg \
+      libsndfile1 \
+    && if ! command -v python3 >/dev/null 2>&1; then \
+      apt-get install -y --no-install-recommends python3 python3-pip python3-venv; \
+    fi \
+    && if ! command -v pip3 >/dev/null 2>&1; then \
+      apt-get install -y --no-install-recommends python3-pip; \
+    fi \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY requirements.txt .
+
+ARG TORCH_INDEX_URL=https://download.pytorch.org/whl/cpu
+
+RUN --mount=type=cache,target=/root/.cache/pip \
+    python3 -m pip install --upgrade pip setuptools wheel \
+    && python3 -m pip install --index-url ${TORCH_INDEX_URL} torch torchaudio \
+    && python3 -m pip install -r requirements.txt \
+    && python3 -m pip install "nemo-toolkit[asr]" huggingface_hub
+
+COPY server.py .
+
+EXPOSE 8000
+
+CMD ["python3", "server.py", "--host", "0.0.0.0", "--port", "8000"]

--- a/inference/nemotron/README.md
+++ b/inference/nemotron/README.md
@@ -1,0 +1,23 @@
+# Nemotron STT Service
+
+This folder contains an OpenAI-compatible FastAPI wrapper for
+`nvidia/nemotron-speech-streaming-en-0.6b`.
+
+It exposes:
+
+- `POST /v1/audio/transcriptions`
+- `GET /v1/models`
+- `GET /health`
+
+The service is used by default in the root `docker-compose.yml` as the STT backend.
+
+## Env vars
+
+- `NEMOTRON_MODEL_NAME` (default: `nvidia/nemotron-speech-streaming-en-0.6b`)
+- `NEMOTRON_MODEL_ID` (default: `nemotron-speech-streaming`)
+
+## Notes
+
+- First startup downloads model weights and can take a while.
+- GPU builds are configured via `docker-compose.gpu.yml`.
+- The root compose file maps host port `11435` to container `8000`.

--- a/inference/nemotron/requirements.txt
+++ b/inference/nemotron/requirements.txt
@@ -1,0 +1,5 @@
+fastapi
+uvicorn[standard]
+python-multipart
+soundfile
+numpy

--- a/inference/nemotron/server.py
+++ b/inference/nemotron/server.py
@@ -1,0 +1,323 @@
+"""
+OpenAI-compatible STT server wrapping NVIDIA's nemotron-speech-streaming-en-0.6b model.
+
+Usage:
+    python server.py [--host 0.0.0.0] [--port 8000]
+"""
+
+import argparse
+import json
+import logging
+import os
+import tempfile
+import time
+from contextlib import asynccontextmanager
+from typing import Optional
+
+import numpy as np
+import soundfile as sf
+import torch
+import uvicorn
+from fastapi import FastAPI, File, Form, HTTPException, UploadFile
+from fastapi.responses import JSONResponse, PlainTextResponse, StreamingResponse
+
+os.environ.setdefault("PYTORCH_ENABLE_MPS_FALLBACK", "1")
+
+logger = logging.getLogger("stt-server")
+logging.basicConfig(level=logging.INFO)
+
+MODEL_NAME = os.getenv("NEMOTRON_MODEL_NAME", "nvidia/nemotron-speech-streaming-en-0.6b")
+MODEL_ID = os.getenv("NEMOTRON_MODEL_ID", "nemotron-speech-streaming")
+TARGET_SAMPLE_RATE = 16000
+
+asr_model = None
+
+
+def load_model():
+    global asr_model
+    logger.info("Loading model %s ...", MODEL_NAME)
+    import nemo.collections.asr as nemo_asr
+
+    asr_model = nemo_asr.models.ASRModel.from_pretrained(MODEL_NAME)
+    asr_model.eval()
+
+    if torch.cuda.is_available():
+        asr_model = asr_model.cuda()
+        logger.info("Model on CUDA")
+    elif torch.backends.mps.is_available():
+        try:
+            asr_model = asr_model.to("mps")
+            logger.info("Model on MPS")
+        except Exception:
+            logger.info("MPS unavailable for this model, using CPU")
+    else:
+        logger.info("Model on CPU")
+
+    logger.info("Model loaded successfully")
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    load_model()
+    yield
+
+
+app = FastAPI(title="Nemotron STT Server", lifespan=lifespan)
+
+
+def load_audio(audio_bytes: bytes, filename: str) -> np.ndarray:
+    """Load audio bytes, resample to 16kHz mono, return float32 numpy array."""
+    suffix = os.path.splitext(filename)[1] if filename else ".wav"
+
+    with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as tmp_in:
+        tmp_in.write(audio_bytes)
+        tmp_in_path = tmp_in.name
+
+    try:
+        data, sample_rate = sf.read(tmp_in_path, dtype="float32")
+    except Exception:
+        import torchaudio
+
+        waveform, sample_rate = torchaudio.load(tmp_in_path)
+        data = waveform.numpy()
+        if data.ndim == 2:
+            data = data.mean(axis=0)
+    finally:
+        os.unlink(tmp_in_path)
+
+    if data.ndim > 1:
+        data = data.mean(axis=-1) if data.shape[-1] <= data.shape[0] else data.mean(axis=0)
+
+    if sample_rate != TARGET_SAMPLE_RATE:
+        import torchaudio
+
+        waveform = torch.tensor(data).unsqueeze(0)
+        resampler = torchaudio.transforms.Resample(
+            orig_freq=sample_rate,
+            new_freq=TARGET_SAMPLE_RATE,
+        )
+        waveform = resampler(waveform)
+        data = waveform.squeeze(0).numpy()
+
+    return data
+
+
+def direct_transcribe(audio: np.ndarray) -> str:
+    """Run full-file transcription using direct model forward pass."""
+    audio_tensor = torch.tensor(audio).unsqueeze(0).to(asr_model.device)
+    audio_len = torch.tensor([audio.shape[0]], dtype=torch.long).to(asr_model.device)
+
+    with torch.no_grad():
+        processed, processed_len = asr_model.preprocessor(
+            input_signal=audio_tensor,
+            length=audio_len,
+        )
+        encoded, encoded_len = asr_model.encoder(
+            audio_signal=processed,
+            length=processed_len,
+        )
+        hypotheses = asr_model.decoding.rnnt_decoder_predictions_tensor(
+            encoded,
+            encoded_len,
+            return_hypotheses=False,
+        )
+
+    first_hypothesis = hypotheses[0]
+    return first_hypothesis.text if hasattr(first_hypothesis, "text") else str(first_hypothesis)
+
+
+def streaming_transcribe(audio: np.ndarray):
+    """Yield incremental transcript deltas using conformer_stream_step."""
+    model = asr_model
+    device = model.device
+
+    audio_tensor = torch.tensor(audio).unsqueeze(0).to(device)
+    audio_len = torch.tensor([audio.shape[0]], dtype=torch.long).to(device)
+
+    with torch.no_grad():
+        processed, _processed_len = model.preprocessor(
+            input_signal=audio_tensor,
+            length=audio_len,
+        )
+
+        streaming_cfg = model.encoder.streaming_cfg
+        chunk_size = streaming_cfg.chunk_size
+        shift_size = streaming_cfg.shift_size
+
+        chunk_frames = chunk_size[0] if isinstance(chunk_size, (list, tuple)) else chunk_size
+        shift_frames = shift_size[0] if isinstance(shift_size, (list, tuple)) else shift_size
+
+        pre_encode_cache = streaming_cfg.pre_encode_cache_size
+        pre_cache_frames = (
+            pre_encode_cache[0]
+            if isinstance(pre_encode_cache, (list, tuple))
+            else pre_encode_cache
+        )
+
+        total_frames = processed.shape[2]
+        previous_text = ""
+        previous_hypotheses = None
+
+        cache_last_channel, cache_last_time, cache_last_channel_len = (
+            model.encoder.get_initial_cache_state(batch_size=1)
+        )
+
+        if pre_cache_frames > 0:
+            pad = torch.zeros(
+                processed.shape[0],
+                processed.shape[1],
+                pre_cache_frames,
+                device=device,
+                dtype=processed.dtype,
+            )
+            processed = torch.cat([pad, processed], dim=2)
+            total_frames = processed.shape[2]
+
+        offset = 0
+        while offset < total_frames:
+            end = min(offset + chunk_frames, total_frames)
+            chunk = processed[:, :, offset:end]
+            chunk_len = torch.tensor([chunk.shape[2]], dtype=torch.long).to(device)
+
+            result = model.conformer_stream_step(
+                processed_signal=chunk,
+                processed_signal_length=chunk_len,
+                cache_last_channel=cache_last_channel,
+                cache_last_time=cache_last_time,
+                cache_last_channel_len=cache_last_channel_len,
+                previous_hypotheses=previous_hypotheses,
+                return_transcription=True,
+            )
+
+            (
+                _greedy_preds,
+                all_hypotheses,
+                cache_last_channel,
+                cache_last_time,
+                cache_last_channel_len,
+                best_hypothesis,
+            ) = result
+
+            if best_hypothesis and len(best_hypothesis) > 0:
+                hypothesis = best_hypothesis[0]
+                current_text = (
+                    hypothesis.text if hasattr(hypothesis, "text") else str(hypothesis)
+                )
+            elif isinstance(all_hypotheses, list) and len(all_hypotheses) > 0:
+                first = all_hypotheses[0]
+                if isinstance(first, str):
+                    current_text = first
+                elif hasattr(first, "text"):
+                    current_text = first.text
+                else:
+                    current_text = str(first)
+            else:
+                current_text = ""
+
+            previous_hypotheses = best_hypothesis
+
+            if current_text and current_text != previous_text:
+                delta = current_text[len(previous_text) :]
+                if delta:
+                    yield delta
+                previous_text = current_text
+
+            offset += shift_frames
+
+
+async def sse_generator(audio: np.ndarray):
+    """Generate SSE events from streaming transcription."""
+    full_text = ""
+    for delta in streaming_transcribe(audio):
+        full_text += delta
+        event = {"type": "transcript.text.delta", "delta": delta}
+        yield f"data: {json.dumps(event)}\n\n"
+
+    done_event = {"type": "transcript.text.done", "text": full_text.strip()}
+    yield f"data: {json.dumps(done_event)}\n\n"
+    yield "data: [DONE]\n\n"
+
+
+@app.post("/v1/audio/transcriptions")
+async def transcribe(
+    file: UploadFile = File(...),
+    model: str = Form(MODEL_ID),
+    response_format: Optional[str] = Form("json"),
+    stream: Optional[str] = Form(None),
+    language: Optional[str] = Form(None),
+    temperature: Optional[str] = Form(None),
+    prompt: Optional[str] = Form(None),
+):
+    del model, language, temperature, prompt
+
+    if asr_model is None:
+        raise HTTPException(status_code=503, detail="Model not loaded yet")
+
+    is_stream = stream is not None and stream.lower() in ("true", "1", "yes")
+
+    audio_bytes = await file.read()
+    if not audio_bytes:
+        raise HTTPException(status_code=400, detail="Empty audio file")
+
+    try:
+        audio = load_audio(audio_bytes, file.filename or "audio.wav")
+    except Exception as error:
+        raise HTTPException(status_code=400, detail=f"Failed to process audio: {error}")
+
+    if is_stream:
+        return StreamingResponse(
+            sse_generator(audio),
+            media_type="text/event-stream",
+            headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+        )
+
+    try:
+        text = direct_transcribe(audio)
+    except Exception as error:
+        logger.exception("Transcription failed")
+        raise HTTPException(status_code=500, detail=f"Transcription failed: {error}")
+
+    if response_format == "text":
+        return PlainTextResponse(content=text)
+    if response_format == "verbose_json":
+        return JSONResponse(
+            content={
+                "text": text,
+                "task": "transcribe",
+                "language": "en",
+                "duration": None,
+            }
+        )
+
+    return JSONResponse(content={"text": text})
+
+
+@app.get("/v1/models")
+async def list_models():
+    return JSONResponse(
+        content={
+            "object": "list",
+            "data": [
+                {
+                    "id": MODEL_ID,
+                    "object": "model",
+                    "created": int(time.time()),
+                    "owned_by": "nvidia",
+                }
+            ],
+        }
+    )
+
+
+@app.get("/health")
+async def health():
+    return {"status": "ok", "model_loaded": asr_model is not None}
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Nemotron STT Server")
+    parser.add_argument("--host", default="0.0.0.0")
+    parser.add_argument("--port", type=int, default=8000)
+    arguments = parser.parse_args()
+
+    uvicorn.run(app, host=arguments.host, port=arguments.port)

--- a/livekit_agent/.env.example
+++ b/livekit_agent/.env.example
@@ -1,3 +1,13 @@
 LIVEKIT_URL=http://localhost:7880
 LIVEKIT_API_KEY=devkey
 LIVEKIT_API_SECRET=secret
+
+# STT backend (defaults to Nemotron)
+STT_PROVIDER=nemotron
+STT_BASE_URL=http://localhost:11435/v1
+STT_MODEL=nemotron-speech-streaming
+STT_API_KEY=no-key-needed
+
+# LLM backend
+LLAMA_BASE_URL=http://localhost:11436/v1
+LLAMA_MODEL=qwen3-4b

--- a/livekit_agent/src/agent.py
+++ b/livekit_agent/src/agent.py
@@ -61,12 +61,31 @@ async def my_agent(ctx: JobContext):
     llama_model = os.getenv("LLAMA_MODEL", "qwen3-4b")
     llama_base_url = os.getenv("LLAMA_BASE_URL", "http://llama_cpp:11434/v1")
 
+    stt_provider = os.getenv("STT_PROVIDER", "nemotron").lower()
+    if stt_provider == "whisper":
+        default_stt_base_url = "http://whisper:80/v1"
+        default_stt_model = "Systran/faster-whisper-small"
+    else:
+        default_stt_base_url = "http://nemotron:8000/v1"
+        default_stt_model = "nemotron-speech-streaming"
+
+    stt_base_url = os.getenv("STT_BASE_URL", default_stt_base_url)
+    stt_model = os.getenv("STT_MODEL", default_stt_model)
+    stt_api_key = os.getenv("STT_API_KEY", "no-key-needed")
+
+    logger.info(
+        "Starting agent with STT provider=%s model=%s base_url=%s",
+        stt_provider,
+        stt_model,
+        stt_base_url,
+    )
+
     session = AgentSession(
         stt=openai.STT(
-            base_url="http://whisper:80/v1",
+            base_url=stt_base_url,
             # base_url="http://localhost:11435/v1", # uncomment for local testing
-            model="Systran/faster-whisper-small",
-            api_key="no-key-needed"
+            model=stt_model,
+            api_key=stt_api_key
         ),
         llm=openai.LLM(
             base_url=llama_base_url,


### PR DESCRIPTION
## Summary
- Add `inference/nemotron` OpenAI-compatible STT service (FastAPI)
- Make Nemotron the default STT backend in `livekit_agent`
- Keep Whisper as optional fallback via compose profile
- Update compose/env/docs for provider-based STT config

## Smoke + benchmark
Benchmarked on a small CPU-only Openclaw host using 10 generated clips x 2 runs (20 req/model):
- Nemotron: avg 535.5 ms, p95 614.9 ms, WER 11.10%
- Whisper: avg 2891.6 ms, p95 3011.4 ms, WER 14.53%
- Speedup: 5.4x avg, 4.9x p95 in favor of Nemotron
