### PR TITLE
feat: delta/final streaming display + thinking indicator control

### DIFF
--- a/frontend/components/app/session-view.tsx
+++ b/frontend/components/app/session-view.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { motion } from 'motion/react';
-import { useSessionContext, useSessionMessages } from '@livekit/components-react';
+import { useSessionContext } from '@livekit/components-react';
 import type { AppConfig } from '@/app-config';
-import { ChatTranscript } from '@/components/app/chat-transcript';
+import { ChatTranscript, type StatusIndicator } from '@/components/app/chat-transcript';
 import { PreConnectMessage } from '@/components/app/preconnect-message';
 import { TileLayout } from '@/components/app/tile-layout';
 import {
@@ -13,6 +13,7 @@ import {
 } from '@/components/livekit/agent-control-bar/agent-control-bar';
 import { cn } from '@/lib/utils';
 import { ScrollArea } from '../livekit/scroll-area/scroll-area';
+import { useHelixMessages } from '@/hooks/useHelixMessages';
 
 const MotionBottom = motion.create('div');
 
@@ -56,6 +57,12 @@ export function Fade({ top = false, bottom = false, className }: FadeProps) {
   );
 }
 
+// ── 状態インジケータ定義 ──
+type AgentStatusState = 'thinking' | 'speaking' | null;
+const STATUS_THINKING: StatusIndicator = { emoji: '💭', text: '回答を考えています…' };
+const STATUS_LISTENING: StatusIndicator = { emoji: '👂', text: '聞いています…' };
+const STATUS_SEARCHING: StatusIndicator = { emoji: '🔍', text: '検索中です…' };
+
 interface SessionViewProps {
   appConfig: AppConfig;
 }
@@ -65,8 +72,11 @@ export const SessionView = ({
   ...props
 }: React.ComponentProps<'section'> & SessionViewProps) => {
   const session = useSessionContext();
-  const { messages } = useSessionMessages(session);
-  const [chatOpen, setChatOpen] = useState(false);
+  const { messages, streaming } = useHelixMessages(session?.room);
+  const [chatOpen, setChatOpen] = useState(true);
+  const [agentState, setAgentState] = useState<AgentStatusState>(null);
+  const [isSpeaking, setIsSpeaking] = useState(false);
+  const [deepSearching, setDeepSearching] = useState(false);
   const scrollAreaRef = useRef<HTMLDivElement>(null);
 
   const controls: ControlBarControls = {
@@ -77,14 +87,58 @@ export const SessionView = ({
     screenShare: appConfig.supportsVideoInput,
   };
 
+  // Deep Search status 購読（DataChannel経由）
+  const myAgentIdentityRef = useRef<string | null>(null);
   useEffect(() => {
-    const lastMessage = messages.at(-1);
-    const lastMessageIsLocal = lastMessage?.from?.isLocal === true;
+    const room = session?.room;
+    if (!room) return;
+    const handler = (payload: Uint8Array, participant: any) => {
+      try {
+        const data = JSON.parse(new TextDecoder().decode(payload));
+        if (data.type !== 'deep_search_status') return;
+        const identity = participant?.identity;
+        if (!myAgentIdentityRef.current) {
+          if (!identity || identity.startsWith('user_')) return;
+          myAgentIdentityRef.current = identity;
+        }
+        if (identity !== myAgentIdentityRef.current) return;
+        setDeepSearching(data.status === 'start');
+      } catch { /* ignore */ }
+    };
+    room.on('dataReceived', handler);
+    return () => { room.off('dataReceived', handler); };
+  }, [session?.room]);
 
-    if (scrollAreaRef.current && lastMessageIsLocal) {
-      scrollAreaRef.current.scrollTop = scrollAreaRef.current.scrollHeight;
+  // 状態インジケータの優先度決定
+  // isSpeaking > deepSearch > thinking（delta受信中はthinking非表示）
+  const statusIndicator: StatusIndicator | null = (() => {
+    if (isSpeaking) return STATUS_LISTENING;
+    if (deepSearching) return STATUS_SEARCHING;
+    if (agentState === 'thinking' && !streaming) return STATUS_THINKING;
+    return null;
+  })();
+
+  // 新しいメッセージが来たら最下部へスクロール
+  useEffect(() => {
+    const el = scrollAreaRef.current;
+    if (!el) return;
+    const isNearBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 100;
+    const lastMessage = messages.at(-1);
+    const lastMessageIsLocal = lastMessage?.role === 'user';
+    if (lastMessageIsLocal || isNearBottom) {
+      el.scrollTop = el.scrollHeight;
     }
   }, [messages]);
+
+  // インジケータ変化時も自動スクロール（末尾付近のときのみ）
+  useEffect(() => {
+    const el = scrollAreaRef.current;
+    if (!el || !statusIndicator) return;
+    const isNearBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 100;
+    if (isNearBottom) {
+      el.scrollTop = el.scrollHeight;
+    }
+  }, [statusIndicator]);
 
   return (
     <section className="bg-background relative z-10 h-full w-full overflow-hidden" {...props}>
@@ -96,12 +150,16 @@ export const SessionView = ({
         )}
       >
         <Fade top className="absolute inset-x-4 top-0 h-40" />
-        <ScrollArea ref={scrollAreaRef} className="px-4 pt-40 pb-[150px] md:px-6 md:pb-[200px]">
+        <ScrollArea ref={scrollAreaRef} className="px-4 pt-16 pb-[220px] md:px-6 md:pb-[260px]">
           <ChatTranscript
             hidden={!chatOpen}
             messages={messages}
+            status={statusIndicator}
             className="mx-auto max-w-2xl space-y-3 transition-opacity duration-300 ease-out"
           />
+          {appConfig.isPreConnectBufferEnabled && (
+            <PreConnectMessage messages={messages} className="pb-4" />
+          )}
         </ScrollArea>
       </div>
 
@@ -113,9 +171,6 @@ export const SessionView = ({
         {...BOTTOM_VIEW_MOTION_PROPS}
         className="fixed inset-x-3 bottom-0 z-50 md:inset-x-12"
       >
-        {appConfig.isPreConnectBufferEnabled && (
-          <PreConnectMessage messages={messages} className="pb-4" />
-        )}
         <div className="bg-background relative mx-auto max-w-2xl pb-3 md:pb-12">
           <Fade bottom className="absolute inset-x-0 top-0 h-4 -translate-y-full" />
           <AgentControlBar

--- a/frontend/hooks/useHelixMessages.ts
+++ b/frontend/hooks/useHelixMessages.ts
@@ -1,0 +1,129 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import type { Room } from 'livekit-client';
+
+export interface HelixMessage {
+  id: string;
+  role: 'user' | 'assistant';
+  text: string; // raw — 一切加工しない
+  ts: number;
+  part?: number; // 分割送信時のパート番号
+  parts?: number; // 総パート数
+  kind?: 'delta' | 'final';
+  seq?: number; // delta連番
+  finalized?: boolean; // finalで確定済み
+}
+
+const TOPIC = 'helix.chat';
+
+/**
+ * 統一メッセージストリーム(helix.chat)の購読。
+ * assistantは同一msg_idでdelta(差分逐次)→final(確定全文置換)を受信する。
+ * deltaはseq順に結合してidベースupsert、finalは800B分割を再結合して全文置換する。
+ * userはfinalのみ表示。interim/transcription表示は廃止済み。
+ */
+export function useHelixMessages(room?: Room): {
+  messages: HelixMessage[];
+  streaming: boolean; // delta受信中（未finalized assistant有り）
+} {
+  const [messages, setMessages] = useState<HelixMessage[]>([]);
+  const [streaming, setStreaming] = useState(false);
+  const partsBufRef = useRef<Map<string, Map<number, string>>>(new Map());
+  // delta結合用: id -> (seq -> text)。seq順に連結して逐次表示する。
+  const deltaBufRef = useRef<Map<string, Map<number, string>>>(new Map());
+  // final確定済みid。delta遅延到着を同期判定で弾き、deltaBufのリークを防ぐ。
+  const finalizedIdsRef = useRef<Set<string>>(new Set());
+
+  useEffect(() => {
+    if (!room) return;
+    const handler = async (reader: any) => {
+      const dbgId = `dbg_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`;
+      setMessages((prev) => [
+        ...prev,
+        {
+          id: dbgId,
+          role: 'assistant',
+          text: `📩 受信開始 (size=${reader?.info?.size ?? '?'})`,
+          ts: Date.now(),
+        },
+      ]);
+      try {
+        const raw = await reader.readAll();
+        // 受信成功 → マーカーを除去
+        setMessages((prev) => prev.filter((m) => m.id !== dbgId));
+        const msg = JSON.parse(raw) as HelixMessage;
+        if (!msg.id || !msg.role || typeof msg.text !== 'string') return;
+
+        // ── delta(差分逐次): seq順に結合してidベースupsert ──
+        if (msg.kind === 'delta') {
+          // A: final確定済みなら結合もbuf生成も再描画も行わない（リーク防止）
+          if (finalizedIdsRef.current.has(msg.id)) return;
+          const buf = deltaBufRef.current.get(msg.id) ?? new Map<number, string>();
+          buf.set(msg.seq ?? 0, msg.text);
+          deltaBufRef.current.set(msg.id, buf);
+          const maxSeq = Math.max(...buf.keys());
+          const joined = Array.from({ length: maxSeq + 1 }, (_, i) => buf.get(i) ?? '').join('');
+          setMessages((prev) => {
+            const idx = prev.findIndex((m) => m.id === msg.id);
+            if (idx === -1) {
+              return [...prev, { id: msg.id, role: msg.role, text: joined, ts: msg.ts, finalized: false }];
+            }
+            // final確定後はdeltaを無視（順序逆転対策）
+            if (prev[idx].finalized) return prev;
+            const next = prev.slice();
+            next[idx] = { ...next[idx], text: joined };
+            return next;
+          });
+          setStreaming(true);
+          return;
+        }
+
+        // ── final(確定): 800B分割を再結合して全文置換 ──
+        const totalParts = msg.parts ?? 1;
+        let finalText = msg.text;
+        if (totalParts > 1) {
+          const buf = partsBufRef.current.get(msg.id) ?? new Map<number, string>();
+          buf.set(msg.part ?? 0, msg.text);
+          partsBufRef.current.set(msg.id, buf);
+          if (buf.size < totalParts) return; // 全パート未着
+          finalText = Array.from({ length: totalParts }, (_, i) => buf.get(i) ?? '').join('');
+          partsBufRef.current.delete(msg.id);
+        }
+        finalizedIdsRef.current.add(msg.id);
+        deltaBufRef.current.delete(msg.id);
+        setStreaming(false);
+        setMessages((prev) => {
+          const idx = prev.findIndex((m) => m.id === msg.id);
+          if (idx === -1) {
+            return [...prev, { id: msg.id, role: msg.role, text: finalText, ts: msg.ts, finalized: true }];
+          }
+          const next = prev.slice();
+          next[idx] = { ...next[idx], text: finalText, finalized: true };
+          return next;
+        });
+      } catch (e) {
+        console.error('helix.chat parse failed:', e);
+        setMessages((prev) => [
+          ...prev,
+          {
+            id: `err_${Date.now()}`,
+            role: 'assistant',
+            text: `⚠️ メッセージ受信エラー: ${String(e)}`,
+            ts: Date.now(),
+          },
+        ]);
+      }
+    };
+    room.registerTextStreamHandler(TOPIC, handler);
+    return () => {
+      try {
+        room.unregisterTextStreamHandler(TOPIC);
+      } catch {
+        /* already unregistered */
+      }
+    };
+  }, [room]);
+
+  return { messages, streaming };
+}


### PR DESCRIPTION
- Add useHelixMessages hook: id-based upsert for delta streaming, 800B part reassembly for final, finalizedIds guard for leak prevention
- Update session-view: use streaming flag to suppress thinking indicator during delta reception, helix.chat unified stream subscription
- Pairs with helix-ai PR #49 (agent.py delta/final protocol)